### PR TITLE
feat: add open interest retrieval and unsubscribe methods to WebsocketPublicClient, along with corresponding tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderly-connector-rs"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "A Rust client library for interacting with the Orderly Network API"
 license = "MIT"

--- a/src/rest/client.rs
+++ b/src/rest/client.rs
@@ -425,6 +425,36 @@ impl OrderlyService {
         self.send_public_request(request).await
     }
 
+    /// Get open interest for all trading pairs.
+    /// GET /v1/public/market_info/traders_open_interests
+    ///
+    /// This endpoint provides open interest information for all trading pairs,
+    /// showing the total long and short positions held by traders.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the open interest information for all trading pairs.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use orderly_connector_rs::rest::OrderlyService;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let service = OrderlyService::new(true, None).unwrap();
+    /// let open_interests = service.get_open_interest().await.expect("Failed to get open interests");
+    /// println!("Open interests: {:?}", open_interests);
+    /// # }
+    /// ```
+    ///
+    /// https://orderly.network/docs/build-on-omnichain/evm-api/restful-api/public/get-open-interests-for-all-symbols
+    pub async fn get_open_interest(&self) -> Result<GetOpenInterestResponse> {
+        let path = "/v1/public/market_info/traders_open_interests";
+        let url = self.base_url.join(path)?;
+        let request = self.http_client.get(url).build()?;
+        self.send_public_request(request).await
+    }
+
     // --- Private Endpoints (Orders) ---
 
     /// Creates a new order for the specified user.

--- a/src/types.rs
+++ b/src/types.rs
@@ -699,6 +699,93 @@ impl<'a> IntoIterator for &'a GetFundingRateHistoryResponse {
     }
 }
 
+// ===== Open Interest =====
+
+/// Represents open interest data for a trading pair.
+///
+/// # Fields
+///
+/// * `symbol` - The trading pair symbol (e.g., "PERP_BTC_USDC")
+/// * `long_oi` - Total long open interest, expected to be non-negative
+/// * `short_oi` - Total short open interest, represented as a negative number or zero
+#[derive(Deserialize, Debug, Clone)]
+pub struct OpenInterest {
+    pub symbol: String,
+    /// Total long open interest, expected to be non-negative
+    pub long_oi: f64,
+    /// Total short open interest, represented as a negative number or zero
+    pub short_oi: f64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct GetOpenInterestResponseData {
+    pub rows: Vec<OpenInterest>,
+}
+
+// Iterator implementation for response data
+impl IntoIterator for GetOpenInterestResponseData {
+    type Item = OpenInterest;
+    type IntoIter = std::vec::IntoIter<OpenInterest>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.rows.into_iter()
+    }
+}
+
+// Reference iterator implementation for response data
+impl<'a> IntoIterator for &'a GetOpenInterestResponseData {
+    type Item = &'a OpenInterest;
+    type IntoIter = std::slice::Iter<'a, OpenInterest>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.rows.iter()
+    }
+}
+
+pub type GetOpenInterestResponse = SuccessResponse<GetOpenInterestResponseData>;
+
+// Iterator implementation for open interest
+pub struct OpenInterestIterator {
+    response: GetOpenInterestResponse,
+    index: usize,
+}
+
+impl Iterator for OpenInterestIterator {
+    type Item = OpenInterest;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.response.data.rows.len() {
+            let item = self.response.data.rows[self.index].clone();
+            self.index += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+}
+
+impl IntoIterator for GetOpenInterestResponse {
+    type Item = OpenInterest;
+    type IntoIter = OpenInterestIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        OpenInterestIterator {
+            response: self,
+            index: 0,
+        }
+    }
+}
+
+// Also implement iterator for reference to avoid consuming the response
+impl<'a> IntoIterator for &'a GetOpenInterestResponse {
+    type Item = &'a OpenInterest;
+    type IntoIter = std::slice::Iter<'a, OpenInterest>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.rows.iter()
+    }
+}
+
 // ===== Algo Orders =====
 
 // TODO: Define request/response structs for Algo Orders

--- a/src/websocket/client.rs
+++ b/src/websocket/client.rs
@@ -516,6 +516,38 @@ impl WebsocketPublicClient {
         self.subscribe(msg).await
     }
 
+    /// Unsubscribe from real-time ticker updates.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the unsubscription request was sent successfully,
+    /// or an error if the request failed or the connection is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use orderly_connector_rs::websocket::WebsocketPublicClient;
+    /// # use std::sync::Arc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let client = WebsocketPublicClient::connect(
+    /// #     "account_id".to_string(),
+    /// #     true,
+    /// #     Arc::new(|msg| println!("{}", msg)),
+    /// #     Arc::new(|| println!("Closed")),
+    /// # ).await.unwrap();
+    /// client.unsubscribe_tickers().await.expect("Failed to unsubscribe from tickers");
+    /// # }
+    /// ```
+    pub async fn unsubscribe_tickers(&self) -> Result<()> {
+        let msg = json!({
+            "id": "unsubscribe_tickers",
+            "topic": "tickers",
+            "event": "unsubscribe"
+        });
+        self.unsubscribe(msg).await
+    }
+
     /// Subscribe to real-time orderbook updates for a specific trading pair.
     ///
     /// Orderbook updates include:
@@ -556,6 +588,43 @@ impl WebsocketPublicClient {
             "event": "subscribe"
         });
         self.subscribe(msg).await
+    }
+
+    /// Unsubscribe from real-time orderbook updates for a specific trading pair.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading pair symbol (e.g., "PERP_ETH_USDC")
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the unsubscription request was sent successfully,
+    /// or an error if the request failed or the connection is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use orderly_connector_rs::websocket::WebsocketPublicClient;
+    /// # use std::sync::Arc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let client = WebsocketPublicClient::connect(
+    /// #     "account_id".to_string(),
+    /// #     true,
+    /// #     Arc::new(|msg| println!("{}", msg)),
+    /// #     Arc::new(|| println!("Closed")),
+    /// # ).await.unwrap();
+    /// client.unsubscribe_orderbook("PERP_ETH_USDC").await.expect("Failed to unsubscribe from orderbook");
+    /// # }
+    /// ```
+    pub async fn unsubscribe_orderbook(&self, symbol: &str) -> Result<()> {
+        let topic = format!("orderbook@{}", symbol);
+        let msg = json!({
+            "id": format!("unsubscribe_orderbook_{}", symbol),
+            "topic": topic,
+            "event": "unsubscribe"
+        });
+        self.unsubscribe(msg).await
     }
 
     /// Subscribe to real-time open interest updates for a specific trading pair.

--- a/src/websocket/client.rs
+++ b/src/websocket/client.rs
@@ -558,6 +558,48 @@ impl WebsocketPublicClient {
         self.subscribe(msg).await
     }
 
+    /// Subscribe to real-time open interest updates for a specific trading pair.
+    ///
+    /// Open interest updates include:
+    /// - Total long positions
+    /// - Total short positions
+    /// - Updates every 1 second if changed, or 10 seconds force update
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading pair symbol (e.g., "PERP_ETH_USDC")
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the subscription request was sent successfully,
+    /// or an error if the request failed or the connection is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use orderly_connector_rs::websocket::WebsocketPublicClient;
+    /// # use std::sync::Arc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let client = WebsocketPublicClient::connect(
+    /// #     "account_id".to_string(),
+    /// #     true,
+    /// #     Arc::new(|msg| println!("{}", msg)),
+    /// #     Arc::new(|| println!("Closed")),
+    /// # ).await.unwrap();
+    /// client.subscribe_open_interest("PERP_ETH_USDC").await.expect("Failed to subscribe to open interest");
+    /// # }
+    /// ```
+    pub async fn subscribe_open_interest(&self, symbol: &str) -> Result<()> {
+        let topic = format!("{}@openinterest", symbol);
+        let msg = json!({
+            "id": format!("subscribe_openinterest_{}", symbol),
+            "topic": topic,
+            "event": "subscribe"
+        });
+        self.subscribe(msg).await
+    }
+
     /// Subscribe to the liquidation push stream.
     ///
     /// Provides real-time updates about liquidation events across the platform.
@@ -598,6 +640,75 @@ impl WebsocketPublicClient {
             "topic": "liquidation"
         });
         self.subscribe(msg).await
+    }
+
+    /// Unsubscribe from real-time open interest updates for a specific trading pair.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading pair symbol (e.g., "PERP_ETH_USDC")
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the unsubscription request was sent successfully,
+    /// or an error if the request failed or the connection is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use orderly_connector_rs::websocket::WebsocketPublicClient;
+    /// # use std::sync::Arc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let client = WebsocketPublicClient::connect(
+    /// #     "account_id".to_string(),
+    /// #     true,
+    /// #     Arc::new(|msg| println!("{}", msg)),
+    /// #     Arc::new(|| println!("Closed")),
+    /// # ).await.unwrap();
+    /// client.unsubscribe_open_interest("PERP_ETH_USDC").await.expect("Failed to unsubscribe from open interest");
+    /// # }
+    /// ```
+    pub async fn unsubscribe_open_interest(&self, symbol: &str) -> Result<()> {
+        let topic = format!("{}@openinterest", symbol);
+        let msg = json!({
+            "id": format!("unsubscribe_openinterest_{}", symbol),
+            "topic": topic,
+            "event": "unsubscribe"
+        });
+        self.unsubscribe(msg).await
+    }
+
+    /// Unsubscribe from the liquidation push stream.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the unsubscription request was sent successfully,
+    /// or an error if the request failed or the connection is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use orderly_connector_rs::websocket::WebsocketPublicClient;
+    /// # use std::sync::Arc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let client = WebsocketPublicClient::connect(
+    /// #     "account_id".to_string(),
+    /// #     true,
+    /// #     Arc::new(|msg| println!("{}", msg)),
+    /// #     Arc::new(|| println!("Closed")),
+    /// # ).await.unwrap();
+    /// client.unsubscribe_liquidations().await.expect("Failed to unsubscribe from liquidations");
+    /// # }
+    /// ```
+    pub async fn unsubscribe_liquidations(&self) -> Result<()> {
+        let msg = json!({
+            "id": "unsub_liquidations",
+            "event": "unsubscribe",
+            "topic": "liquidation"
+        });
+        self.unsubscribe(msg).await
     }
 
     // --- Stop Method ---
@@ -1008,6 +1119,108 @@ impl WebsocketPrivateClient {
             "event": "subscribe"
         });
         self.subscribe(msg).await
+    }
+
+    /// Unsubscribe from position updates.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the unsubscription request was sent successfully,
+    /// or an error if the request failed or the connection is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use orderly_connector_rs::websocket::WebsocketPrivateClient;
+    /// # use std::sync::Arc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let client = WebsocketPrivateClient::connect(
+    /// #     "api_key".to_string(),
+    /// #     "secret".to_string(),
+    /// #     "account_id".to_string(),
+    /// #     true,
+    /// #     Arc::new(|msg| println!("{}", msg)),
+    /// #     Arc::new(|| println!("Closed")),
+    /// # ).await.unwrap();
+    /// client.unsubscribe_positions().await.expect("Failed to unsubscribe from positions");
+    /// # }
+    /// ```
+    pub async fn unsubscribe_positions(&self) -> Result<()> {
+        let msg = json!({
+            "id": "unsub_positions",
+            "event": "unsubscribe",
+            "topic": "position"
+        });
+        self.unsubscribe(msg).await
+    }
+
+    /// Unsubscribe from execution report updates.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the unsubscription request was sent successfully,
+    /// or an error if the request failed or the connection is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use orderly_connector_rs::websocket::WebsocketPrivateClient;
+    /// # use std::sync::Arc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let client = WebsocketPrivateClient::connect(
+    /// #     "api_key".to_string(),
+    /// #     "secret".to_string(),
+    /// #     "account_id".to_string(),
+    /// #     true,
+    /// #     Arc::new(|msg| println!("{}", msg)),
+    /// #     Arc::new(|| println!("Closed")),
+    /// # ).await.unwrap();
+    /// client.unsubscribe_execution_reports().await.expect("Failed to unsubscribe from execution reports");
+    /// # }
+    /// ```
+    pub async fn unsubscribe_execution_reports(&self) -> Result<()> {
+        let msg = json!({
+            "id": "unsub_execution_reports",
+            "event": "unsubscribe",
+            "topic": "executionreport"
+        });
+        self.unsubscribe(msg).await
+    }
+
+    /// Unsubscribe from balance updates.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the unsubscription request was sent successfully,
+    /// or an error if the request failed or the connection is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use orderly_connector_rs::websocket::WebsocketPrivateClient;
+    /// # use std::sync::Arc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let client = WebsocketPrivateClient::connect(
+    /// #     "api_key".to_string(),
+    /// #     "secret".to_string(),
+    /// #     "account_id".to_string(),
+    /// #     true,
+    /// #     Arc::new(|msg| println!("{}", msg)),
+    /// #     Arc::new(|| println!("Closed")),
+    /// # ).await.unwrap();
+    /// client.unsubscribe_balance().await.expect("Failed to unsubscribe from balance updates");
+    /// # }
+    /// ```
+    pub async fn unsubscribe_balance(&self) -> Result<()> {
+        let msg = json!({
+            "id": "unsub_balance",
+            "event": "unsubscribe",
+            "topic": "balance"
+        });
+        self.unsubscribe(msg).await
     }
 
     // --- Stop Method ---

--- a/tests/websocket_public.rs
+++ b/tests/websocket_public.rs
@@ -1,0 +1,103 @@
+mod common;
+
+use orderly_connector_rs::websocket::WebsocketPublicClient;
+use std::sync::Arc;
+use tokio::time::{sleep, Duration};
+
+/// Tests the WebSocket connection and basic subscription functionality.
+///
+/// This test verifies that:
+/// - The client can establish a WebSocket connection
+/// - Basic subscription messages can be sent
+/// - Messages are received through the callback
+///
+/// Note: This test is ignored by default as it requires network access.
+#[tokio::test]
+#[ignore]
+async fn test_websocket_connection() {
+    common::setup();
+    let is_testnet = common::get_testnet_flag();
+
+    let message_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let message_count_clone = Arc::clone(&message_count);
+
+    let message_handler = Arc::new(move |msg: String| {
+        println!("Received message: {}", msg);
+        message_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    });
+
+    let close_handler = Arc::new(|| {
+        println!("Connection closed");
+    });
+
+    let client = WebsocketPublicClient::connect(
+        "test_account".to_string(),
+        is_testnet,
+        message_handler,
+        close_handler,
+    )
+    .await
+    .expect("Failed to connect");
+
+    // Wait a bit to ensure connection is established
+    sleep(Duration::from_secs(2)).await;
+
+    // Test should pass if we got here without errors
+    client.stop().await;
+}
+
+/// Tests the open interest WebSocket subscription.
+///
+/// This test verifies that:
+/// - The client can subscribe to open interest updates
+/// - Messages are received through the callback
+/// - The received messages contain valid open interest data
+///
+/// Note: This test is ignored by default as it requires network access.
+#[tokio::test]
+#[ignore]
+async fn test_subscribe_open_interest() {
+    common::setup();
+    let is_testnet = common::get_testnet_flag();
+
+    let message_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let message_count_clone = Arc::clone(&message_count);
+
+    let message_handler = Arc::new(move |msg: String| {
+        println!("Received message: {}", msg);
+        // Verify message contains expected open interest fields
+        if msg.contains("openinterest") && msg.contains("long_oi") && msg.contains("short_oi") {
+            message_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    });
+
+    let close_handler = Arc::new(|| {
+        println!("Connection closed");
+    });
+
+    let client = WebsocketPublicClient::connect(
+        "test_account".to_string(),
+        is_testnet,
+        message_handler,
+        close_handler,
+    )
+    .await
+    .expect("Failed to connect");
+
+    // Subscribe to open interest for ETH
+    client
+        .subscribe_open_interest("PERP_ETH_USDC")
+        .await
+        .expect("Failed to subscribe to open interest");
+
+    // Wait to receive some messages
+    sleep(Duration::from_secs(5)).await;
+
+    let final_count = message_count.load(std::sync::atomic::Ordering::SeqCst);
+    println!("Received {} open interest messages", final_count);
+
+    // We should have received at least one message
+    assert!(final_count > 0, "No open interest messages received");
+
+    client.stop().await;
+}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code Refactoring
- [ ] Other (please describe):

## Checklist:

- [ ] My code follows the style guidelines of this project (ran `cargo fmt --check`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (`cargo clippy -- -D warnings`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`cargo test`)
- [ ] Any dependent changes have been merged and published in downstream modules
